### PR TITLE
fix: prosemirror whitespace bug

### DIFF
--- a/libs/frontend/feature-build/src/lib/code-editor-plugins.ts
+++ b/libs/frontend/feature-build/src/lib/code-editor-plugins.ts
@@ -2,26 +2,9 @@ import { schemaCode } from '@pubstudio/frontend/util-edit-text'
 import { Keys } from '@pubstudio/frontend/util-key-listener'
 import hljs from 'highlight.js/lib/core'
 import { keymap } from 'prosemirror-keymap'
-import { Fragment, Slice } from 'prosemirror-model'
 import { Plugin } from 'prosemirror-state'
 import { highlightPlugin } from './prosemirror-highlighthjs-plugin'
-
-// Manually create a new slice instead of using the third parameter `slice` from
-// `handlePaste` because new line characters will be ignored for unknown reason
-// when using it to do content replacement in the editor state.
-const transformPasteContentPlugin = new Plugin({
-  props: {
-    handlePaste: (view, e) => {
-      const pastedContent = e.clipboardData?.getData('text') ?? ''
-      if (pastedContent) {
-        const textNode = schemaCode.text(pastedContent)
-        const slice = new Slice(Fragment.from(textNode), 0, 0)
-        view.dispatch(view.state.tr.replaceSelection(slice))
-      }
-      return true
-    },
-  },
-})
+import { whitespacePasteFixPlugin } from './whitespace-paste-fix-plugin'
 
 // Manually insert a new line instead of using the default behavior to avoid creating
 // a new block of <p> as a sibling of <pre>.
@@ -53,6 +36,6 @@ export const codeEditorPlugins: Plugin[] = [
     },
   }),
   highlightPlugin(hljs),
-  transformPasteContentPlugin,
+  whitespacePasteFixPlugin(schemaCode),
   interceptNewLineEventPlugin,
 ]

--- a/libs/frontend/feature-build/src/lib/create-editor-view.ts
+++ b/libs/frontend/feature-build/src/lib/create-editor-view.ts
@@ -7,6 +7,7 @@ import {
 import { EditorView } from 'prosemirror-view'
 import { ref, Ref } from 'vue'
 import { useBuild } from './use-build'
+import { whitespacePasteFixPlugin } from './whitespace-paste-fix-plugin'
 
 // Use to detect updates in the ProseMirror component edit view
 export const editViewTxCount = ref(0)
@@ -19,8 +20,10 @@ export function createComponentEditorView(
   if (!container) {
     return undefined
   }
+  const plugins = [...(options.plugins ?? []), whitespacePasteFixPlugin(schemaText)]
   const state = prosemirrorSetup({
     ...options,
+    plugins,
     schema: schemaText,
   })
 

--- a/libs/frontend/feature-build/src/lib/whitespace-paste-fix-plugin.ts
+++ b/libs/frontend/feature-build/src/lib/whitespace-paste-fix-plugin.ts
@@ -1,0 +1,19 @@
+import { Plugin } from 'prosemirror-state'
+import { Schema, Slice, Fragment } from 'prosemirror-model'
+
+// Make sure white spaces and new line characters are preserved while pasting.
+export const whitespacePasteFixPlugin = (schema: Schema) => {
+  return new Plugin({
+    props: {
+      handlePaste: (view, e) => {
+        const pastedContent = e.clipboardData?.getData('text') ?? ''
+        if (pastedContent) {
+          const textNode = schema.text(pastedContent)
+          const slice = new Slice(Fragment.from(textNode), 0, 0)
+          view.dispatch(view.state.tr.replaceSelection(slice))
+        }
+        return true
+      },
+    },
+  })
+}


### PR DESCRIPTION
Close #139 

Hi @sampullman 

It seems that this bug is already fixed; I tested it with multiple fonts with space in its names and it seems to work well. It also works when the font is applied to only a part of the text in prosemirror editor.

<img width="984" alt="Screenshot 2023-12-14 at 5 13 43 PM" src="https://github.com/samatechtw/pubstudio-builder/assets/59676941/c006cb03-2d9d-4d72-abe8-2eeb9b54c2df">

However, I noticed copying&pasting space characters in a prosemirror editor of a component won't work if those space characters are copied from any prosemirror editor of a component.

https://github.com/samatechtw/pubstudio-builder/assets/59676941/398e6453-6d99-4aad-8539-2806221266bc

This is strange 🤔. The situation is opposite to that of prosemirror editor for code. I managed to fix it by using the same plugin for #11.
Since #139 is also for a prosemirror editor bug, I just included the fix in this PR 😬. Sorry for the inconvenience!