### PR TITLE
210 input values cleared in preview mode

### DIFF
--- a/libs/frontend/feature-site-store/src/lib/use-site-source.ts
+++ b/libs/frontend/feature-site-store/src/lib/use-site-source.ts
@@ -5,6 +5,8 @@ import {
   ISiteStore,
   SiteSaveState,
 } from '@pubstudio/shared/type-site'
+import { serializeSiteContext, serializePage } from '@pubstudio/frontend/util-site-store'
+import { store } from '@pubstudio/frontend/data-access-web-store'
 import { computed, ComputedRef, Ref, ref } from 'vue'
 
 // This file is here, instead of frontend/feature-site-source, to decouple the `site`
@@ -37,6 +39,11 @@ const isSaving = computed(() => {
 })
 
 export const useSiteSource = (): IUseSiteSource => {
+  // For scratch site.
+  let oldScratchSite = ''
+  // For API site.
+  let oldRestored: ISiteRestore | undefined = undefined
+
   const setRestoredSite = (restored: ISiteRestore | undefined) => {
     if (restored) {
       restoredSite = restored
@@ -60,14 +67,93 @@ export const useSiteSource = (): IUseSiteSource => {
     setRestoredSite(restored)
   }
 
+  // The periodic fetch on the preview page will reset page states, such as
+  // input values and styles added via behavior code. Therefore, we should
+  // only replace the current site when there are changes in content that
+  // will affect the rendered output.
   const checkOutdated = async () => {
-    const restored = await siteStore.value.restore(site.value.updated_at)
-    setRestoredSite(restored)
-    if (restored) {
-      console.log('Site updated:', site.value.updated_at)
+    if (!apiSiteId.value) {
+      // Scratch site
+      await checkScratchSiteOutdated()
     } else {
-      console.log('No site updates')
+      // API site
+      await checkApiSiteOutdated()
     }
+  }
+
+  // Only replace the current site with a new one when content changes.
+  const checkScratchSiteOutdated = async () => {
+    const currentScratchSite = localStorage.getItem('scratch-site-store') ?? ''
+    if (oldScratchSite !== currentScratchSite) {
+      if (currentScratchSite) {
+        const moduleState = JSON.parse(currentScratchSite)
+        store.scratchSite.setSite(moduleState.state)
+      }
+      oldScratchSite = currentScratchSite
+
+      const restored = await siteStore.value.restore(site.value.updated_at)
+      if (restored) {
+        setRestoredSite(restored)
+        console.log('Site updated:', site.value.updated_at)
+      }
+    }
+  }
+
+  // Only replace the current site with a new one when content changes.
+  const checkApiSiteOutdated = async () => {
+    const restored = await siteStore.value.restore(site.value.updated_at)
+
+    if (restored) {
+      const siteChanged = checkSitesChanged(restored)
+      oldRestored = restored
+
+      if (siteChanged) {
+        setRestoredSite(restored)
+        console.log('Site updated:', site.value.updated_at)
+        return
+      }
+    } else {
+      oldRestored = restored
+    }
+
+    console.log('No site updates')
+  }
+
+  // Only compare properties that affects the rendered output of a site.
+  const checkSitesChanged = (newRestored: ISiteRestore) => {
+    if (!oldRestored || !oldRestored.error !== !newRestored.error) {
+      return true
+    }
+
+    // Check site context.
+    const oldContext = serializeSiteContext(oldRestored.site.context)
+    const newContext = serializeSiteContext(newRestored.site.context)
+    if (JSON.stringify(oldContext) !== JSON.stringify(newContext)) {
+      return true
+    }
+
+    // Check site defaults.
+    if (
+      JSON.stringify(oldRestored.site.defaults) !==
+      JSON.stringify(newRestored.site.defaults)
+    ) {
+      return true
+    }
+
+    // Check pages.
+    for (const oldRoute in oldRestored.site.pages) {
+      if (!(oldRoute in newRestored.site.pages)) {
+        return true
+      }
+      const oldPage = serializePage(oldRestored.site.pages[oldRoute])
+      const newPage = serializePage(newRestored.site.pages[oldRoute])
+      if (JSON.stringify(oldPage) !== JSON.stringify(newPage)) {
+        return true
+      }
+    }
+
+    // Everything is the same.
+    return false
   }
 
   return {


### PR DESCRIPTION
Close #210 
Close #216 

Hi @sampullman 

For #210, I didn't think of a good way to solve it. In addition to input values, styles added via behavior code are also cleared after a periodic fetch. I thought I could use the `key` attribute on VNode to preserve some elements during re-render, but unfortunately that didn't work out.

My current solution is to compare the old site and the new site, and only update the site when content that'll affect the rendered output is changed (so things like editor & history are excluded from the check). I worried that this solution may not be very performant, due to the fact that the check is run within every periodic fetch, but I didn't find another way to solve the page-states lost problem 😕.