### PR TITLE
fix: prosemirror up/down skips blank lines

### DIFF
--- a/apps/builder-demo/src/app/App.vue
+++ b/apps/builder-demo/src/app/App.vue
@@ -44,12 +44,14 @@ onMounted(async () => {
   }
 }
 
-.pm-p {
-  &:after {
-    content: '\200b';
-  }
-  &.pm-p-placeholder {
-    cursor: text;
+.component-content-container {
+  .pm-p {
+    &::after {
+      content: '\200b';
+    }
+    &.pm-p-placeholder {
+      cursor: text;
+    }
   }
 }
 

--- a/apps/web-site/src/app/App.vue
+++ b/apps/web-site/src/app/App.vue
@@ -169,7 +169,7 @@ body {
   }
 }
 
-.pm-p:after {
+.pm-p::after {
   content: '\200b';
 }
 

--- a/libs/frontend/feature-preview/src/lib/preview-component.ts
+++ b/libs/frontend/feature-preview/src/lib/preview-component.ts
@@ -31,11 +31,11 @@ export const PreviewComponent = () => {
     setup(props: ILiveComponentProps) {
       const { site, component } = toRefs(props)
       const { custom } = computeEvents(site.value, component.value)
-      registerCustomEvents(component.value, custom, null, true)
+      registerCustomEvents(component.value, custom, null, false)
 
       onMounted(() => {
         const { custom } = computeEvents(site.value, component.value)
-        registerCustomEvents(component.value, custom, null, false)
+        registerCustomEvents(component.value, custom, null, true)
       })
       onUnmounted(() => {
         removeListeners(component.value)

--- a/libs/frontend/feature-template/project.json
+++ b/libs/frontend/feature-template/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend-feature-template",
+  "name": "frontend-feature-template-builder",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/frontend/feature-template/src",
   "projectType": "library",

--- a/libs/frontend/ui-build/src/components/preview/SitePreview.vue
+++ b/libs/frontend/ui-build/src/components/preview/SitePreview.vue
@@ -88,5 +88,8 @@ html {
       flex-shrink: 0;
     }
   }
+  .pm-p::after {
+    content: '\200b';
+  }
 }
 </style>

--- a/libs/frontend/ui-theme/src/css/components/prosemirror-view.postcss
+++ b/libs/frontend/ui-theme/src/css/components/prosemirror-view.postcss
@@ -34,9 +34,6 @@
 .ProseMirror pre {
   white-space: pre-wrap;
 }
-.ProseMirror-trailingBreak {
-  display: none;
-}
 
 .code-wrap {
   width: 100%;

--- a/libs/frontend/util-config/project.json
+++ b/libs/frontend/util-config/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "util-config",
+  "name": "util-config-builder",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/frontend/util-config/src",
   "projectType": "library",

--- a/libs/frontend/util-vite-config/project.json
+++ b/libs/frontend/util-vite-config/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "util-vite-config",
+  "name": "util-vite-config-builder",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/frontend/util-vite-config/src",
   "projectType": "library",

--- a/libs/shared/type-api-local-site/project.json
+++ b/libs/shared/type-api-local-site/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "type-api-local-site",
+  "name": "type-api-local-site-builder",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/type-api-local-site/src",
   "projectType": "library",

--- a/libs/shared/type-api-platform-template/project.json
+++ b/libs/shared/type-api-platform-template/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "type-api-platform-template",
+  "name": "type-api-platform-template-builder",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/type-api-platform-template/src",
   "projectType": "library",


### PR DESCRIPTION
Close #172 

Hi @sampullman 

I think it's finally solved! Turns out the bug is actually caused by one of the default browser behavior instead of ProseMirror.
The same issue can be observed in [this sandbox](https://stackblitz.com/edit/web-platform-egfkum?file=index.html). It seems that `p::after { content: '\200b'; }` with a `<br>` inside will be skipped when using keyboard navigation; the only way to set the cursor to these "empty" lines is clicking them with mouse.

If I remember correctly, `p::after { content: '\200b'; }` was added because empty `<p></p>` will collapse when ProseMirror editor is not active. So I modify the style of `.pm-p` here and there to make sure `::after { content: '\200b'; }` is only applied when the component is not selected (for builder), and when in Preview Page & web-site app.