### PR TITLE
fix: google font link bug

### DIFF
--- a/libs/frontend/feature-render-builder/src/lib/use-render-builder.ts
+++ b/libs/frontend/feature-render-builder/src/lib/use-render-builder.ts
@@ -11,6 +11,7 @@ import {
   renderGoogleFontsLink,
   themeToCssVars,
 } from '@pubstudio/frontend/util-render'
+import { ThemeFontSource } from '@pubstudio/shared/type-site'
 import { computed, defineComponent, h } from 'vue'
 import { computeBuilderReusableStyles } from './compute-builder-reusable-styles'
 import { renderPage } from './render-builder'
@@ -56,9 +57,9 @@ export const useRenderBuilder = (options: IUseRenderOptions): IUseRender => {
   })
 
   const googleFonts = computed(() => {
-    const themeFontNames = Object.values(site.value?.context.theme.fonts ?? {}).map(
-      (font) => font.name,
-    )
+    const themeFontNames = Object.values(site.value?.context.theme.fonts ?? {})
+      .filter((font) => font.source === ThemeFontSource.Google)
+      .map((font) => font.name)
 
     const fontNames = [...themeFontNames]
     for (const googleFontName of selectedGoogleFonts.value) {

--- a/libs/frontend/feature-render/src/lib/use-render.ts
+++ b/libs/frontend/feature-render/src/lib/use-render.ts
@@ -12,7 +12,13 @@ import {
   RenderMode,
   themeToCssVars,
 } from '@pubstudio/frontend/util-render'
-import { Css, CssPseudoClass, IPage, ISite } from '@pubstudio/shared/type-site'
+import {
+  Css,
+  CssPseudoClass,
+  IPage,
+  ISite,
+  ThemeFontSource,
+} from '@pubstudio/shared/type-site'
 import { Link, Meta, Script, useHead } from '@unhead/vue'
 import { Component, computed, ComputedRef, defineComponent, h, Ref } from 'vue'
 import {
@@ -105,9 +111,9 @@ export const useRender = (options: IUseRenderOptions): IUseRender => {
   })
 
   const googleFonts = computed(() => {
-    const fontNames = Object.values(site.value?.context.theme.fonts ?? {}).map(
-      (font) => font.name,
-    )
+    const fontNames = Object.values(site.value?.context.theme.fonts ?? {})
+      .filter((font) => font.source === ThemeFontSource.Google)
+      .map((font) => font.name)
     return renderGoogleFontsLink(fontNames)
   })
 


### PR DESCRIPTION
[#1033](https://github.com/samatechtw/pubstudio/issues/1033)

Turns out the bug is observed because we forgot to filter theme fonts before converting them to Google Font `<link>` 😅. This results in both native fonts and Google fonts to be included in `<link href="...">`.

`https://fonts.googleapis.com/css2?family=Georgia` actually exists, that's why we didn't see a 404 error in the console in this case. Only the 400 font-weight is defined in that CSS file by default, which caused all other font weights to lose effect. So the font weight would be broken right after the Georgia native font is added to the site.

https://github.com/samatechtw/pubstudio-builder/assets/59676941/35de038f-2476-4feb-a716-5ab5363aa75c