### PR TITLE
fix: no bearer in api if token missing

### DIFF
--- a/libs/frontend/util-api/src/lib/api.ts
+++ b/libs/frontend/util-api/src/lib/api.ts
@@ -31,12 +31,16 @@ export class PSApi extends FetchApi<ApiResponse> {
 
   authRequest<T>(config: FetchRequestConfig): Promise<ApiResponse<T>> {
     const { headers, ...rest } = config
-    return this.request<T>({
-      ...rest,
-      headers: {
+    let authHeaders = headers
+    if (this.userToken.value) {
+      authHeaders = {
         ...headers,
         Authorization: `Bearer ${this.userToken.value}`,
-      },
+      }
+    }
+    return this.request<T>({
+      ...rest,
+      headers: authHeaders,
     })
   }
 


### PR DESCRIPTION
When the user is logged out, we were still passing the `Bearer <token>` header, which caused some requests to fail. The API processed the empty bearer token and returned 401, even though the endpoint should be accessible by anonymous users.

The API could be updated to treat a null bearer token as anonymous user, but it seems easier to just omit the auth header in the client.